### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "2.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,13 @@
+{
+  "versions": [
+    {
+      "label": "stable",
+      "checkout": "2.x",
+      "latest": true
+    },
+    {
+      "label": "next",
+      "checkout": "master"
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group=com.enonic.app
 projectName=adfsidprovider
 appName=com.enonic.app.adfsidprovider
 xpVersion=8.0.0-B4
-version=2.1.4-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

Branches out the XP 7 maintenance line and moves master to the next major SNAPSHOT, mirroring the [app-booster](https://github.com/enonic/app-booster) pattern.

- Maintenance branch [`2.x`](https://github.com/enonic/app-adfs-idprovider/tree/2.x) was created from tag `v2.1.3-B1` (commit `fde6741`) — no PR needed for that branch.
- `gradle.properties`: `version` bumped `2.1.4-SNAPSHOT` → `3.0.0-SNAPSHOT`.
- `.github/workflows/enonic-gradle.yml`: added `releaseBranch:` listing `master` and `2.x`, so both branches publish releases.
- `.github/workflows/enonic-docgen.yml`: added `2.x` to `on.push.branches` so docs regenerate on the maintenance line as well.
- `docs/versions.json`: new file declaring `stable` → `2.x` (latest) and `next` → `master` for the docs portal.

`./gradlew clean build` is green locally.

## Test plan

- [ ] CI `Gradle Build` runs green on this branch
- [ ] Verify `2.x` branch exists on GitHub and points at `v2.1.3-B1`'s commit