### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ${{ secrets.ARTIFACTORY_USERNAME }}
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `2.x`, so pushes to the `2.x` maintenance branch are recognized as release-branch pushes by `enonic/release-tools/build-and-publish`.
- Mirrors the equivalent change being made on master in #111. Master-only items (`gradle.properties`, `enonic-docgen.yml`, `docs/versions.json`) are intentionally not touched here.

## Test plan
- [ ] CI run on this branch (`chore/2.x-add-release-branch`) is green.
- [ ] After merge, a push to `2.x` is classified as a release branch by build-and-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)