### PR TITLE
Bump enonic libs to XP8 SNAPSHOTs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 repositories {
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo('dev')
 }
 
 node {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-http-client   = "3.2.2"
-text-encoding = "2.1.1"
+http-client   = "4.0.0-SNAPSHOT"
+text-encoding = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-http-client   = { module = "com.enonic.lib:lib-http-client",   version.ref = "http-client" }


### PR DESCRIPTION
## Summary

Bump enonic-lib deps still pinned to pre-XP8 release versions, and flip the repo to `xp.enonicRepo('dev')` so Gradle can resolve the new SNAPSHOTs.

- `lib-http-client` 3.2.2 → 4.0.0-SNAPSHOT
- `lib-text-encoding` 2.1.1 → 3.0.0-SNAPSHOT
- `xp.enonicRepo()` → `xp.enonicRepo('dev')`

These are the only two enonic libs the app uses; the older releases were compiled against XP 7 APIs.

## Test plan

- [ ] `./gradlew build --refresh-dependencies` resolves both SNAPSHOTs cleanly (no `FAILED`) and tests pass
- [ ] E2E smoke against XP 8 (cold-boot, app reaches ACTIVE, no `NoSuchMethod`/`NoClassDef` from these libs)