### PR TITLE
Drop version-history clutter from docs #119

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -17,7 +17,7 @@ It is compatible with ADFS 3.0 (Windows Server 2012 R2) and ADFS 4.0 (Windows Se
 
 image::idprov.png[Installation,768]
 
-* In your Enonic Virtual Hosting configuration, modify the appropriate mappings so that your site or admin interface uses the user store you created.
+* In your Enonic Virtual Hosting configuration, modify the appropriate mappings so that your site or admin interface uses the ID Provider you created.
 
     # Use ADFS for a site mysite
     mapping.mysite.host = example.com


### PR DESCRIPTION
## Summary

Review of `docs/**` on `master` for "what was added when" clutter.

## What was removed

- `docs/index.adoc` line 20: replaced legacy term `user store` with `ID Provider`. The rest of the docs already use "ID Provider" (see line 14 and elsewhere), and the surrounding vhost example uses `mapping.mysite.idProvider.<name>`. `user store` is pre-XP-6/7 language that no longer belongs in current docs.

## What was deliberately kept

- `docs/index.adoc` line 7 (`compatible with ADFS 3.0 (Windows Server 2012 R2) and ADFS 4.0 (Windows Server 2016)`) — these are Microsoft product versions, not this app's version history. They document real, currently-working upstream compatibility. Newer ADFS versions (2019/2022) likely work too via the standard OAuth2 endpoints, but that's a "modernize compatibility statement" task, not clutter cleanup.
- `docs/adfs.adoc` line 6 (`steps and screenshots … performed on AD FS 4 … AD FS 3 are similar`) — screenshot caveat, still useful operational context.
- `docs/adfs.adoc` line 101 (`Grant … (Not necessary for ADFS 3.0)`) — genuine version-specific caveat for the (rare) ADFS 3.0 user.

## Nothing else needed

- No `(added in vX.Y)` / `(since X.Y)` annotations present.
- No "Starting from version X …" / "Introduced in X" changelog notes present.
- No obsolete pre-XP8 platform notes present (the docs never referenced specific XP versions).

## Scope compliance

- `master` only.
- No `versions.json` restructuring.
- No branch changes.
- `2.x` untouched.

## Verify

- Both `docs/index.adoc` and `docs/adfs.adoc` render with `asciidoctor` without warnings (`--failure-level=WARN`).

Closes #119